### PR TITLE
fix packetSize in struct layout

### DIFF
--- a/Server/MMOServer/Packets/BasePacket.cs
+++ b/Server/MMOServer/Packets/BasePacket.cs
@@ -12,10 +12,10 @@ namespace MMOServer
     [StructLayout(LayoutKind.Sequential)]
     public struct BasePacketHeader
     {
+        public ushort packetSize; //Packet Size: The total size of the packet including header.
         public byte isAuthenticated;
         public byte isEncrypted;
-        public ushort connectionType;
-        public ushort packetSize; //Packet Size: The total size of the packet including header.
+        public ushort connectionType;        
         public ushort numSubpackets;
         public ulong timestamp; //Miliseconds
     }


### PR DESCRIPTION
ushort packetSize = BitConverter.ToUInt16(buffer, offset); is used to check if the buffer  has enough data to build a packet, so the first two bytes of the header must be the packet Size